### PR TITLE
Search mapinfo in library.

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -926,7 +926,8 @@ void LoadStratagusMapInfo(const std::string &mapname)
 		Map.Info.Filename.replace(loc, 4, ".sms");
 	}
 
-	LuaLoadFile(mapname);
+	const std::string filename = LibraryFileName(mapname.c_str());
+	LuaLoadFile(filename);
 }
 
 //@}


### PR DESCRIPTION
This is not a final solution, as the map is searched with a different
algorithm. LibraryFileName should be used for maps too, but it is a bit
messy imo, with searching by default in eg. /sounds/ directory.