### PR TITLE
Fix clang error

### DIFF
--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -1342,7 +1342,7 @@ static int CclDefineUnitType(lua_State *l)
 			type->Parent = LuaToString(l, -1);
 			CUnitType *parent_type = UnitTypeByIdent(type->Parent);
 			if (!parent_type) {
-				LuaError(l, "Unit type %s not defined" _C_ type->Parent);
+				LuaError(l, "Unit type %s not defined" _C_ type->Parent.c_str());
 			}
 			type->Class = parent_type->Class;
 			type->DrawLevel = parent_type->DrawLevel;


### PR DESCRIPTION
```src/unit/script_unittype.cpp:1345:54: error: cannot pass non-trivial object of type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') to variadic function; expected type from format string was 'char *' [-Wnon-pod-varargs]```