### PR TITLE
Switch back to memmove because regions overlap.

### DIFF
--- a/src/pathfinder/astar.cpp
+++ b/src/pathfinder/astar.cpp
@@ -463,8 +463,7 @@ static void AStarReplaceNode(int pos)
 	// Remove the outdated node
 	node = OpenSet[pos];
 	OpenSetSize--;
-	//memmove(&OpenSet[pos], &OpenSet[pos+1], sizeof(Open) * (OpenSetSize-pos));
-	memcpy(&OpenSet[pos], &OpenSet[pos + 1], sizeof(Open) * (OpenSetSize - pos));
+	memmove(&OpenSet[pos], &OpenSet[pos+1], sizeof(Open) * (OpenSetSize-pos));
 
 	// Re-add the node with the new cost
 	AStarAddNode(node.pos, node.O, node.Costs);


### PR DESCRIPTION
The funny that it was memmove originally. And was commented out in a commit with message:
[PARALLEL DRAWING THREAD (WELCOME IN MULTITHREADED HELL)](http://bazaar.launchpad.net/~stratagus/stratagus/trunk/revision/7704)
