### PR TITLE
Add helper script to build Steam binaries with only minimal dependencies

### DIFF
--- a/tools/build-steam-binary.sh
+++ b/tools/build-steam-binary.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Build a binary for Wyrmgus against the Steam runtime
+
+# Error out if we are not at the root of the source directory
+if [ ! -d ./src ]
+then
+    echo -e "The ./src directory seems not to be present."
+    exit 1
+fi
+
+# Append 32 or 64 to the binary name depending on the arch
+archsuffix=$(getconf LONG_BIT)
+binname=wyrmsun$archsuffix
+
+cmake \
+      -DENABLE_STATIC=OFF \
+      -DWITH_BZIP2=OFF \
+      -DWITH_FLUIDSYNTH=OFF \
+      -DWITH_MIKMOD=ON \
+      -DWITH_MNG=OFF \
+      -DWITH_OGGVORBIS=ON \
+      -DWITH_THEORA=OFF \
+      -DWITH_STACKTRACE=OFF \
+      -DWITH_X11=ON \
+      $@
+
+# Hack to link lua 5.1 statically
+sed -i -e 's/liblua5.1.so/liblua5.1.a/g' CMakeCache.txt
+
+NCPUS_MAX=`/usr/bin/getconf _NPROCESSORS_ONLN`
+make -j$NCPUS_MAX
+
+mv -f stratagus $binname


### PR DESCRIPTION
Here's the small script I use to generate the Steam binaries. It will be simpler if it lives directly in the source tree.