### PR TITLE
Fixed a serious compiler warning

### DIFF
--- a/src/map/tileset.cpp
+++ b/src/map/tileset.cpp
@@ -712,6 +712,8 @@ unsigned CTileset::getWallDirection(int tileIndex, bool human) const
 			return i;
 		}
 	}
+	
+	return 0;
 }
 
 unsigned CTileset::getHumanWallTileIndex(int dirFlag) const


### PR DESCRIPTION
Currently trying to package your game for @openSUSE games and the test scripts delete the build

```
I: Program returns random data in a function
E: wyrmgus no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/Wyrmgus-1.8.3/src/map/tileset.cpp:715
```

This should fix it. I didn't test for regressions. Seems to be some kind of formalism to me.