### PR TITLE
While loading a map window will not freeze any more

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -973,6 +973,54 @@ static void GameTypeManTeamVsMachine()
 --  Game creation
 ----------------------------------------------------------------------------*/
 
+static int itemsToLoad;
+static int itemsLoaded;
+static CGraphic *loadingEmpty = NULL;
+static CGraphic *loadingFull = NULL;
+
+void CalculateItemsToLoad()
+{
+	itemsLoaded = 0;
+	itemsToLoad = 0;
+
+	if (CanAccessFile("ui/loadingEmpty.png") == false || CanAccessFile("ui/loadingFull.png") == false) {
+		return;
+	}
+
+	itemsToLoad+= GetIconsCount();
+	itemsToLoad+= GetCursorsCount(PlayerRaces.Name[ThisPlayer->Race]);
+	itemsToLoad+= GetUnitTypesCount();
+	itemsToLoad+= GetDecorationsCount();
+	itemsToLoad+= GetConstructionsCount();
+	itemsToLoad+= GetMissileSpritesCount();
+
+	loadingEmpty = CGraphic::New("ui/loadingEmpty.png");
+	loadingEmpty->Load();
+	loadingFull = CGraphic::New("ui/loadingFull.png");
+	loadingFull->Load();
+}
+
+void UpdateLoadingBar()
+{
+	if (itemsToLoad == 0)
+		return;
+
+	int x = Video.Width/2 - loadingEmpty->Width/2;
+	int y = Video.Height/2 - loadingEmpty->Height/2;
+	int pct = (itemsLoaded * 100) / itemsToLoad;
+
+	loadingEmpty->DrawClip(x, y);
+	loadingFull->DrawSub(0, 0, (loadingFull->Width * pct) / 100, loadingFull->Height, x, y);
+}
+
+void IncItemsLoaded()
+{
+	if (itemsToLoad == 0 || itemsLoaded >= itemsToLoad)
+		return;
+
+	itemsLoaded++;
+}
+
 /**
 **  CreateGame.
 **
@@ -1123,6 +1171,8 @@ void CreateGame(const std::string &filename, CMap *map)
 	//
 	// Graphic part
 	//
+	CalculateItemsToLoad();
+
 	SetPlayersPalette();
 	LoadIcons();
 

--- a/src/include/construct.h
+++ b/src/include/construct.h
@@ -172,6 +172,8 @@ public:
 extern void InitConstructions();
 /// Load the graphics for constructions
 extern void LoadConstructions();
+/// Count the amount of constructions to load
+extern int GetConstructionsCount();
 /// Clean up the constructions module
 extern void CleanConstructions();
 /// Get construction by identifier

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -179,6 +179,9 @@ extern PixelPos CursorStartMapPos; /// the same in screen map coordinate system
 --  Functions
 ----------------------------------------------------------------------------*/
 
+/// Get amount of cursors to load
+extern int GetCursorsCount(const std::string &racename);
+
 /// Load all cursors
 extern void LoadCursors(const std::string &racename);
 

--- a/src/include/icons.h
+++ b/src/include/icons.h
@@ -156,6 +156,7 @@ public:
 ----------------------------------------------------------------------------*/
 
 extern void LoadIcons();   /// Load icons
+extern int  GetIconsCount();
 extern void CleanIcons();  /// Cleanup icons
 
 //@}

--- a/src/include/missile.h
+++ b/src/include/missile.h
@@ -597,6 +597,8 @@ extern void MissileCclRegister();
 
 /// load all missile sprites
 extern void LoadMissileSprites();
+/// count missile sprites
+extern int GetMissileSpritesCount();
 /// allocate an empty missile-type slot
 extern MissileType *NewMissileTypeSlot(const std::string &ident);
 /// Get missile-type by ident

--- a/src/include/missileconfig.h
+++ b/src/include/missileconfig.h
@@ -48,6 +48,7 @@ public:
 
 	bool MapMissileNoLog();
 	bool MapMissile();
+	bool IsEmpty() { return Name.empty(); }
 
 public:
 	std::string Name;        /// Config missile name

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -626,6 +626,10 @@ extern void CallHandler(unsigned int handle, int value);
 /// Show load progress
 extern void ShowLoadProgress(const char *fmt, ...) PRINTF_VAARG_ATTRIBUTE(1, 2);
 
+extern void CalculateItemsToLoad();
+extern void UpdateLoadingBar();
+extern void IncItemsLoaded();
+
 //@}
 
 #endif // !__UI_H__

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -709,6 +709,8 @@ extern void DrawSelectionCorners(IntColor, int, int, int, int);
 
 /// Register CCL decorations features
 extern void DecorationCclRegister();
+/// Get the amount of decorations
+extern int GetDecorationsCount();
 /// Load the decorations (health,mana) of units
 extern void LoadDecorations();
 /// Clean the decorations (health,mana) of units

--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -1026,6 +1026,7 @@ extern void DrawUnitType(const CUnitType &type, CPlayerColorGraphic *sprite,
 
 extern void InitUnitTypes(int reset_player_stats);   /// Init unit-type table
 extern void LoadUnitTypeSprite(CUnitType &unittype); /// Load the sprite for a unittype
+extern int GetUnitTypesCount();                     /// Get the amount of unit-types
 extern void LoadUnitTypes();                     /// Load the unit-type data
 extern void CleanUnitTypes();                    /// Cleanup unit-type module
 

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -552,6 +552,9 @@ extern const EventCallback *GetCallbacks();
 /// Process all system events. Returns if the time for a frame is over
 extern void WaitEventsOneFrame();
 
+/// Poll all sdl events
+extern void PollEvents();
+
 /// Toggle full screen mode
 extern void ToggleFullScreen();
 

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -99,6 +99,15 @@ void MissileType::LoadMissileSprite()
 	}
 }
 
+int GetMissileSpritesCount()
+{
+#ifndef DYNAMIC_LOAD
+	return MissileTypes.size();
+#else
+	return 0;
+#endif
+}
+
 /**
 **  Load the graphics for all missiles types
 */

--- a/src/missile/missileconfig.cpp
+++ b/src/missile/missileconfig.cpp
@@ -49,14 +49,16 @@ bool MissileConfig::MapMissileNoLog()
 
 bool MissileConfig::MapMissile()
 {
-	bool res = MapMissileNoLog() ;
+	bool res = MapMissileNoLog();
 	if (res == true) {
 		if (Name.empty() == false) {
 			ShowLoadProgress(_("Missile %s"), Name.c_str());
+			IncItemsLoaded();
 		}
 	} else {
 		fprintf(stderr, _("Can't find missile %s\n"), Name.c_str());
 	}
+
 	return res;
 }
 

--- a/src/missile/missileconfig.cpp
+++ b/src/missile/missileconfig.cpp
@@ -39,25 +39,25 @@
 
 bool MissileConfig::MapMissileNoLog()
 {
-	if (this->Name.empty()) {
-		this->Missile = NULL;
+	if (Name.empty()) {
+		Missile = NULL;
 		return true;
 	}
-	this->Missile = MissileTypeByIdent(this->Name);
-	return this->Missile != NULL;
+	Missile = MissileTypeByIdent(Name);
+	return Missile != NULL;
 }
 
 bool MissileConfig::MapMissile()
 {
-	if (MapMissileNoLog() == true) {
-		if (this->Name.empty() == false) {
-			ShowLoadProgress(_("Missile %s"), this->Name.c_str());
+	bool res = MapMissileNoLog() ;
+	if (res == true) {
+		if (Name.empty() == false) {
+			ShowLoadProgress(_("Missile %s"), Name.c_str());
 		}
-		return true;
 	} else {
-		fprintf(stderr, _("Can't find missile %s\n"), this->Name.c_str());
-		return false;
+		fprintf(stderr, _("Can't find missile %s\n"), Name.c_str());
 	}
+	return res;
 }
 
 //@}

--- a/src/stratagus/construct.cpp
+++ b/src/stratagus/construct.cpp
@@ -99,6 +99,7 @@ void CConstruction::Load()
 		this->Sprite = CPlayerColorGraphic::New(file, this->Width, this->Height);
 		this->Sprite->Load();
 		this->Sprite->Flip();
+		IncItemsLoaded();
 	}
 	file = this->ShadowFile.File;
 	this->ShadowWidth = this->ShadowFile.Width;
@@ -109,6 +110,7 @@ void CConstruction::Load()
 		this->ShadowSprite->Load();
 		this->ShadowSprite->Flip();
 		this->ShadowSprite->MakeShadow();
+		IncItemsLoaded();
 	}
 }
 
@@ -118,6 +120,31 @@ void CConstruction::Load()
 */
 void InitConstructions()
 {
+}
+
+
+/**
+**  Return the amount of constructions.
+*/
+int GetConstructionsCount()
+{
+	int count = 0;
+	for (std::vector<CConstruction *>::iterator it = Constructions.begin();
+		 it != Constructions.end();
+		 ++it) {
+		 CConstruction *c = *it;
+		if (c->Ident.empty()) {
+			continue;
+		}
+
+		std::string file = c->File.File;
+		if (!file.empty()) count++;
+
+		file = c->ShadowFile.File;
+		if (!file.empty()) count++;
+
+	}
+	return count;
 }
 
 /**

--- a/src/ui/icons.cpp
+++ b/src/ui/icons.cpp
@@ -305,6 +305,14 @@ bool IconConfig::Load()
 }
 
 /**
+**  Get the numbers of icons.
+*/
+int GetIconsCount()
+{
+	return Icons.size();
+}
+
+/**
 **  Load the graphics for the icons.
 */
 void LoadIcons()
@@ -314,6 +322,8 @@ void LoadIcons()
 
 		ShowLoadProgress(_("Icons %s"), icon.G->File.c_str());
 		icon.Load();
+
+		IncItemsLoaded();
 	}
 }
 

--- a/src/ui/icons.cpp
+++ b/src/ui/icons.cpp
@@ -295,13 +295,13 @@ bool IconConfig::LoadNoLog()
 */
 bool IconConfig::Load()
 {
-	if (LoadNoLog() == true) {
+	bool res = LoadNoLog();
+	if (res == true) {
 		ShowLoadProgress(_("Icon %s"), this->Name.c_str());
-		return true;
 	} else {
 		fprintf(stderr, _("Can't find icon %s\n"), this->Name.c_str());
-		return false;
 	}
+	return res;
 }
 
 /**

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -101,6 +101,8 @@ void ShowLoadProgress(const char *fmt, ...)
 //		InvalidateArea(5, Video.Height - 18, Video.Width - 10, 18);
 		InvalidateArea(0, Video.Height - 18, Video.Width, 18);
 		//Wyrmgus end
+
+		UpdateLoadingBar();
 		RealizeVideoMemory();
 	} else {
 		DebugPrint("!!!!%s\n" _C_ temp);

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -105,6 +105,8 @@ void ShowLoadProgress(const char *fmt, ...)
 	} else {
 		DebugPrint("!!!!%s\n" _C_ temp);
 	}
+
+	PollEvents();
 }
 
 CUnitInfoPanel::~CUnitInfoPanel()

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -414,6 +414,14 @@ void DecorationCclRegister()
 }
 
 /**
+**  Return the amount of decorations.
+*/
+int GetDecorationsCount()
+{
+	return DecoSprite.SpriteArray.size();
+}
+
+/**
 **  Load decoration.
 */
 void LoadDecorations()

--- a/src/unit/unittype.cpp
+++ b/src/unit/unittype.cpp
@@ -1516,6 +1516,28 @@ void LoadUnitTypeSprite(CUnitType &type)
 	//Wyrmgus end
 }
 
+
+/**
+** Return the amount of unit-types.
+*/
+int GetUnitTypesCount()
+{
+	int count = 0;
+	for (std::vector<CUnitType *>::size_type i = 0; i < UnitTypes.size(); ++i) {
+		CUnitType &type = *UnitTypes[i];
+
+		if (type.Missile.IsEmpty() == false) count++;
+		if (type.FireMissile.IsEmpty() == false) count++;
+		if (type.Explosion.IsEmpty() == false) count++;
+
+
+		if (!type.Sprite) {
+			count++;
+		}
+	}
+	return count;
+}
+
 /**
 ** Load the graphics for the unit-types.
 */
@@ -1564,6 +1586,8 @@ void LoadUnitTypes()
 		if (!type.Sprite) {
 			ShowLoadProgress(_("Unit \"%s\""), type.Name.c_str());
 			LoadUnitTypeSprite(type);
+
+			IncItemsLoaded();
 		}
 #endif
 		// FIXME: should i copy the animations of same graphics?

--- a/src/video/cursor.cpp
+++ b/src/video/cursor.cpp
@@ -89,6 +89,28 @@ static SDL_Surface *HiddenSurface;
 ----------------------------------------------------------------------------*/
 
 /**
+**  Get the amount of cursors sprites to load
+*/
+int GetCursorsCount(const std::string &race)
+{
+	int count = 0;
+	for (std::vector<CCursor *>::iterator i = AllCursors.begin(); i != AllCursors.end(); ++i) {
+		CCursor &cursor = **i;
+
+		//  Only load cursors of this race or universal cursors.
+		if (!cursor.Race.empty() && cursor.Race != race) {
+			continue;
+		}
+
+		if (cursor.G && !cursor.G->IsLoaded()) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/**
 **  Load all cursor sprites.
 **
 **  @param race  Cursor graphics of this race to load.
@@ -107,6 +129,8 @@ void LoadCursors(const std::string &race)
 			ShowLoadProgress(_("Cursor %s"), cursor.G->File.c_str());
 			cursor.G->Load();
 			cursor.G->UseDisplayFormat();
+
+			IncItemsLoaded();
 		}
 	}
 }

--- a/src/video/sdl.cpp
+++ b/src/video/sdl.cpp
@@ -125,7 +125,7 @@ static std::map<std::string, int> Str2Key;
 
 double FrameTicks;     /// Frame length in ms
 
-const EventCallback *Callbacks;
+const EventCallback *Callbacks = NULL;
 
 static bool RegenerateScreen = false;
 bool IsSDLWindowVisible = true;
@@ -902,6 +902,24 @@ const EventCallback *GetCallbacks()
 	return Callbacks;
 }
 
+int PollEvent()
+{
+	SDL_Event event;
+	if (SDL_PollEvent(&event)) { // Handle SDL event
+		SdlDoEvent(*GetCallbacks(), event);
+		return 1;
+	}
+
+	return 0;
+}
+
+void PollEvents()
+{
+	if (Callbacks == NULL) return;
+
+	while (PollEvent()) { }
+}
+
 /**
 **  Wait for interactive input event for one frame.
 **
@@ -939,11 +957,7 @@ void WaitEventsOneFrame()
 			NextFrameTicks += FrameTicks;
 		}
 
-		SDL_Event event[1];
-		const int i = SDL_PollEvent(event);
-		if (i) { // Handle SDL event
-			SdlDoEvent(*GetCallbacks(), *event);
-		}
+		int i = PollEvent();
 
 		// Network
 		int s = 0;


### PR DESCRIPTION
Whenever you loaded a map window was getting freeze until the map loaded completely, due to the lack of SDL_PollEvent, now the ShowLoadProgress poll the events and removes that freeze. 