### PR TITLE
Implemented code for OAML's SetMainLoopCondition and AddTension

### DIFF
--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -71,6 +71,14 @@
 #include "video.h"
 
 #include <guichan.h>
+
+#ifdef USE_OAML
+#include <oaml.h>
+
+extern oamlApi *oaml;
+extern bool enableOAML;
+#endif
+
 void DrawGuichanWidgets();
 
 //----------------------------------------------------------------------------
@@ -417,6 +425,13 @@ static void GameLogicLoop()
 	// FIXME: We need find better place!
 	SaveGameLoading = false;
 
+#ifdef USE_OAML
+	if (enableOAML && oaml) {
+		// Time of day can change our main music loop, if the current playing track is set for this
+		oaml->SetMainLoopCondition(GameTimeOfDay);
+	}
+#endif
+
 	//
 	// Game logic part
 	//
@@ -486,6 +501,14 @@ static void GameLogicLoop()
 				// indoors it is always dark (maybe would be better to allow a special setting to have bright indoor places?
 				GameTimeOfDay = NoTimeOfDay; // make indoors have no time of day setting until it is possible to make light sources change their surrounding "time of day"
 			}
+
+#ifdef USE_OAML
+			if (enableOAML && oaml) {
+				// Time of day can change our main music loop, if the current playing track is set for this
+				oaml->SetMainLoopCondition(GameTimeOfDay);
+			}
+#endif
+
 			//update the sight of all units
 			for (CUnitManager::Iterator it = UnitManager.begin(); it != UnitManager.end(); ++it) {
 				CUnit &unit = **it;

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -4612,6 +4612,7 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile, bool show_damage)
 //Wyrmgus end
 {
+	const CUnitType *type = target.Type;
 	if (!damage) {
 		// Can now happen by splash damage
 		// Multiple places send x/y as damage, which may be zero
@@ -4629,6 +4630,17 @@ void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile,
 
 	Assert(damage != 0 && target.CurrentAction() != UnitActionDie && !target.Type->BoolFlag[VANISHES_INDEX].value);
 
+	//Wyrmgus start
+	if ((attacker != NULL && attacker->Player == ThisPlayer) &&
+		target.Player != ThisPlayer &&
+		(type->Building == 1 ||
+		type->CanAttack == 1)
+		) {
+		// If player is hitting or being hit add tension to our music
+		AddMusicTension(1);
+	}
+	//Wyrmgus end
+
 	if (GodMode) {
 		if (attacker && attacker->Player == ThisPlayer) {
 			damage = target.Variable[HP_INDEX].Value;
@@ -4638,7 +4650,6 @@ void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile,
 		}
 	}
 	HitUnit_LastAttack(attacker, target);
-	const CUnitType *type = target.Type;
 	if (attacker) {
 		target.DamagedType = ExtraDeathIndex(attacker->Type->DamageType.c_str());
 	}


### PR DESCRIPTION
SetMainLoopCondition is used for playing different music in day/night (if used by the theme)
AddTension is used to play a battle music when units starts attacking each other or to buildings (only the adaptive themes implement this)