### PR TITLE
Improved FindTolua++ module and FSF address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+     51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -305,7 +305,7 @@ the "copyright" line and a pointer to where the full notice is found.
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 
 Also add information on how to contact you by electronic and paper mail.

--- a/cmake/modules/FindTolua++.cmake
+++ b/cmake/modules/FindTolua++.cmake
@@ -11,20 +11,24 @@
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
+set(TOLUA++_FOUND false)
 if(TOLUA++_INCLUDE_DIR AND TOLUA++_LIBRARY AND TOLUA++_APP)
 	set(TOLUA++_FOUND true)
 else()
 	find_path(TOLUA++_INCLUDE_DIR tolua++.h)
-	find_library(TOLUA++_LIBRARY NAMES tolua++ tolua++5.1 toluapp)
-	find_program(TOLUA++_APP NAMES tolua++ tolua++5.1 toluapp)
+	find_library(TOLUA++_LIBRARY NAMES tolua++ tolua++5.1 tolua++-5.1 toluapp)
+	find_program(TOLUA++_APP NAMES tolua++ tolua++5.1 tolua++-5.1 toluapp)
 
-	if(TOLUA++_INCLUDE_DIR AND TOLUA++_LIBRARY AND TOLUA++_APP)
-		set(TOLUA++_FOUND true)
-		message(STATUS "Found program tolua++: ${TOLUA++_APP}")
+	if(TOLUA++_INCLUDE_DIR AND TOLUA++_LIBRARY)
 		message(STATUS "Found library tolua++: ${TOLUA++_LIBRARY}")
+		if(TOLUA++_APP)
+			set(TOLUA++_FOUND true)
+			message(STATUS "Found program tolua++: ${TOLUA++_APP}")
+		else()
+			message(FATAL_ERROR "Could not find tolua++ program")
+		endif()
 	else()
-		set(TOLUA++_FOUND false)
-		message(FATAL_ERROR "Could not find library or program tolua++")
+		message(FATAL_ERROR "Could not find library or tolua++ include path")
 	endif()
 
 	mark_as_advanced(TOLUA++_INCLUDE_DIR AND TOLUA++_LIBRARY AND TOLUA++_APP)


### PR DESCRIPTION
This fixes the tolua++ detection at least on openSUSE (maybe this is also required by other distributions).
So this is a working version of https://github.com/Andrettin/Wyrmgus/pull/51 ;-)

Also I have updated the FSF address in the COPYING file.