### PR TITLE
Fix -Werror=format-security error

### DIFF
--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -556,7 +556,7 @@ void CUnit::Release(bool final)
 	}
 	//Wyrmgus start
 	if (Orders.size() != 1) {
-		fprintf(stderr, "Unit to be released has more than 1 order; Unit Type: \"%s\", Orders: %d, First Order Type: %d.\n", this->Type->Ident.c_str(), Orders.size(), this->CurrentAction());
+		fprintf(stderr, "Unit to be released has more than 1 order; Unit Type: \"%s\", Orders: %d, First Order Type: %d.\n", this->Type->Ident.c_str(), (int)Orders.size(), this->CurrentAction());
 	}
 	//Wyrmgus end
 	Assert(Orders.size() == 1);
@@ -2154,7 +2154,7 @@ void CUnit::UpdateSoldUnits()
 			new_unit->GenerateSpecialProperties(this);
 			new_unit->Identified = true;
 			if (new_unit->Unique && this->Player == ThisPlayer) { //send a notification if a unique item is being sold, we don't want the player to have to worry about missing it :)
-				this->Player->Notify(NotifyGreen, this->tilePos, this->MapLayer, _("Unique item available for sale"));
+				this->Player->Notify(NotifyGreen, this->tilePos, this->MapLayer, "%s", _("Unique item available for sale"));
 			}
 		}
 		new_unit->Remove(this);


### PR DESCRIPTION
Fixes the following warning and error:
```
[ 90%] Building CXX object CMakeFiles/stratagus.dir/src/unit/unit.cpp.o
/bin/c++   -DHAVE_GETOPT -DHAVE_STRCASESTR -DHAVE_STRNLEN -DPIXMAPS=\"/usr/share/pixmaps\" -DUSE_LINUX -DUSE_MIKMOD -DUSE_OAML -DUSE_OPENGL -DUSE_THEORA -DUSE_VORBIS -DUSE_X11 -DUSE_ZLIB -I/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/include -I/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/guichan/include -I/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/guichan/include/guichan -I/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/xbrz/include -I/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/build -I/usr/include/. -I/usr/include/SDL  -std=c++11 -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fsigned-char -std=c++11 -DNDEBUG   -o CMakeFiles/stratagus.dir/src/unit/unit.cpp.o -c /home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/unit/unit.cpp
/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/unit/unit.cpp: In member function 'void CUnit::Release(bool)':
/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/unit/unit.cpp:559:183: warning: format '%d' expects argument of type 'int', but argument 4 has type 'std::vector<COrder*>::size_type {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "Unit to be released has more than 1 order; Unit Type: \"%s\", Orders: %d, First Order Type: %d.\n", this->Type->Ident.c_str(), Orders.size(), this->CurrentAction());
                                                                                                                                                                                       ^
/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/unit/unit.cpp: In member function 'void CUnit::UpdateSoldUnits()':
/home/akien/Mageia/Checkout/wyrmsun/BUILD/Wyrmgus-2.7.1/src/unit/unit.cpp:2153:105: error: format not a string literal and no format arguments [-Werror=format-security]
     this->Player->Notify(NotifyGreen, this->tilePos, this->MapLayer, _("Unique item available for sale"));
                                                                                                         ^
```

Those are raised using Mageia's flags for C++ packaging:
```
-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4
```

Those flags are pretty common, so you might want to add at least `-Wformat -Werror=format-security` to your config.