### PR TITLE
FindOAML: Support new shared library name

### DIFF
--- a/cmake/modules/FindOAML.cmake
+++ b/cmake/modules/FindOAML.cmake
@@ -23,10 +23,18 @@ find_package(VorbisFile)
 
 if(OGGVORBIS_FOUND AND VORBISFILE_FOUND)
 	find_path(OAML_INCLUDE_DIRS oaml.h)
-	find_library(OAML_LIBRARY_STATIC oaml)
+	find_library(OAML_LIBRARY_STATIC NAMES liboaml.a)
 	find_library(OAML_LIBRARY_SHARED oaml_shared)
-	find_library(OAML_LIBRARY_STATIC_DEBUG oaml_d)
+	# Shared library named changed right after v1.2
+	if (NOT OAML_LIBRARY_SHARED)
+		find_library(OAML_LIBRARY_SHARED oaml)
+	endif()
+	find_library(OAML_LIBRARY_STATIC_DEBUG liboaml_d.a)
 	find_library(OAML_LIBRARY_SHARED_DEBUG oaml_shared_d)
+	# Shared library named changed right after v1.2
+	if (NOT OAML_LIBRARY_SHARED_DEBUG)
+		find_library(OAML_LIBRARY_SHARED_DEBUG oaml_d)
+	endif()
 
 	if (OAML_LIBRARY_SHARED AND OAML_INCLUDE_DIRS)
 		set(OAML_FOUND "YES")


### PR DESCRIPTION
CMake's `find_library` seems to still have no proper support for distinguishing between static and shared library... hopefully this logic works, but I don't fully guarantee it (at least it works to locate the shared library on my system).