### PR TITLE
Fix format-security errors

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2010,7 +2010,7 @@ bool UnitCanBeAt(const CUnit &unit, const Vec2i &pos, int z)
 */
 void PreprocessMap()
 {
-	ShowLoadProgress(_("Initializing Map"));
+	ShowLoadProgress("%s", _("Initializing Map"));
 		
 	//Wyrmgus start
 	/*

--- a/src/stratagus/construct.cpp
+++ b/src/stratagus/construct.cpp
@@ -155,7 +155,7 @@ int GetConstructionsCount()
 */
 void LoadConstructions()
 {
-	ShowLoadProgress(_("Loading Construction Graphics"));
+	ShowLoadProgress("%s", _("Loading Construction Graphics"));
 		
 	for (std::vector<CConstruction *>::iterator it = Constructions.begin();
 		 it != Constructions.end();

--- a/src/ui/icons.cpp
+++ b/src/ui/icons.cpp
@@ -377,7 +377,7 @@ int GetIconsCount()
 */
 void LoadIcons()
 {
-	ShowLoadProgress(_("Loading Icons"));
+	ShowLoadProgress("%s", _("Loading Icons"));
 		
 	for (IconMap::iterator it = Icons.begin(); it != Icons.end(); ++it) {
 		CIcon &icon = *(*it).second;

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -209,7 +209,7 @@ CPopup *PopupByIdent(const std::string &ident)
 */
 void InitUserInterface()
 {
-	ShowLoadProgress(_("Loading User Interface"));
+	ShowLoadProgress("%s", _("Loading User Interface"));
 	
 	UI.Offset640X = (Video.Width - 640) / 2;
 	UI.Offset480Y = (Video.Height - 480) / 2;

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -426,7 +426,7 @@ int GetDecorationsCount()
 */
 void LoadDecorations()
 {
-	ShowLoadProgress(_("Loading Decorations"));
+	ShowLoadProgress("%s", _("Loading Decorations"));
 		
 	std::vector<Decoration>::iterator i;
 	for (i = DecoSprite.SpriteArray.begin(); i != DecoSprite.SpriteArray.end(); ++i) {

--- a/src/video/cursor.cpp
+++ b/src/video/cursor.cpp
@@ -120,7 +120,7 @@ int GetCursorsCount(const std::string &race)
 void LoadCursors(const std::string civilization_name)
 //Wyrmgus end
 {
-	ShowLoadProgress(_("Loading Cursors"));
+	ShowLoadProgress("%s", _("Loading Cursors"));
 			
 	for (std::vector<CCursor *>::iterator i = AllCursors.begin(); i != AllCursors.end(); ++i) {
 		CCursor &cursor = **i;


### PR DESCRIPTION
A cleaner solution could be to define a `ShowLoadProgress(const char *str) { ShowLoadProgress("%s", str); }`, but I'm not familiar with the vararg magic you used in `src/include/ui.h` so I'll leave it to you if you think it's a good idea.