### PR TITLE
Added draw missiles DYNAMIC_LOAD flag code

### DIFF
--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1083,7 +1083,7 @@ void MissileType::DrawMissileType(int frame, const PixelPos &pos) const
 {
 #ifdef DYNAMIC_LOAD
 	if (!this->G->IsLoaded()) {
-		LoadMissileSprite(this);
+		((MissileType*)this)->LoadMissileSprite();
 	}
 #endif
 
@@ -1145,8 +1145,8 @@ void Missile::DrawMissile(const CViewport &vp) const
 	// FIXME: I should copy SourcePlayer for second level missiles.
 	if (sunit && sunit->Player) {
 #ifdef DYNAMIC_LOAD
-		if (!this->Type->Sprite) {
-			LoadMissileSprite(this->Type);
+		if (!this->Type->G->IsLoaded()) {
+			((MissileType*)this->Type)->LoadMissileSprite();
 		}
 #endif
 	}


### PR DESCRIPTION
This code is needed to allocate missiles sprites into memory before drawing