### PR TITLE
Fix some -Wformat errors in prints

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -241,7 +241,7 @@ void game::save_delayed_effects(CFile &file, const std::vector<std::unique_ptr<d
 	}
 
 	str += "_delayed_effects(\"" + string::escaped(delayed_effects_data.print_to_string()) + "\")\n";
-	file.printf(str.c_str());
+	file.printf("%s", str.c_str());
 }
 
 template <typename scope_type>

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1313,7 +1313,7 @@ void SetTimeOfDay(const std::string &time_of_day_ident, int z)
 void SetTimeOfDaySchedule(const std::string &time_of_day_schedule_ident, const int z)
 {
 	if (z >= static_cast<int>(CMap::Map.MapLayers.size())) {
-		fprintf(stderr, "Error in CMap::SetTimeOfDaySchedule: the given map layer index (%d) is not valid given the map layer quantity (%d).\n", z, CMap::Map.MapLayers.size());
+		fprintf(stderr, "Error in CMap::SetTimeOfDaySchedule: the given map layer index (%d) is not valid given the map layer quantity (%ld).\n", z, CMap::Map.MapLayers.size());
 		return;
 	}
 


### PR DESCRIPTION
Size is a long unsigned int.

Fixes:
```
/home/akien/Projects/mageia/Checkout/wyrmsun/BUILD/Wyrmgus-4.1.2/src/map/map.cpp: In function 'void SetTimeOfDaySchedule(const string&, int)':
/home/akien/Projects/mageia/Checkout/wyrmsun/BUILD/Wyrmgus-4.1.2/src/map/map.cpp:1316:132: warning: format '%d' expects argument of type 'int', but argument 4 has type 'std::vector<std::unique_ptr<CMapLayer> >::size_type' {aka 'long unsigned int'} [-Wformat=]
 1316 |   fprintf(stderr, "Error in CMap::SetTimeOfDaySchedule: the given map layer index (%d) is not valid given the map layer quantity (%d).\n", z, CMap::Map.MapLayers.size());
      |                                                                                                                                   ~^          ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                    |                                  |
      |                                                                                                                                    int                                std::vector<std::unique_ptr<CMapLayer> >::size_type {aka long unsigned int}
      |                                                                                                                                   %ld
```