### PR TITLE
CMake: Fix installation of wyrmgus executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1811,7 +1811,7 @@ endif()
 
 ########### install files ###############
 
-install(TARGETS stratagus DESTINATION ${GAMEDIR})
+install(TARGETS stratagus_main DESTINATION ${GAMEDIR})
 
 if(ENABLE_METASERVER)
 	install(TARGETS metaserver DESTINATION ${SBINDIR})


### PR DESCRIPTION
Follow-up to b24fec1e7feabeadcb633738cec85280e297b53f, fixes #165.