### PR TITLE
Fix build issue on aarch64

### DIFF
--- a/src/video/renderer.h
+++ b/src/video/renderer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #pragma warning(push, 0)
+#include <GL/gl.h>
 #include <QOpenGLTexture>
 #include <QOpenGLTextureBlitter>
 #pragma warning(pop)


### PR DESCRIPTION
By importing GL/gl.h explicitly, we're able to build Wyrmgus successfully on aarch64.

Without this, we see failures similar to:
```
[  348s] In file included from /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/unit/unit_draw.cpp:64,
[  348s]                  from /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/build/CMakeFiles/wyrmgus.dir/Unity/unity_unit_cxx.cxx:25:
[  348s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h: In member function 'void wyrmgus::renderer::setup_native_opengl_state()':
[  348s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:75:30: error: 'GL_FLAT' was not declared in this scope; did you mean 'GL_FLOAT'?
[  348s]    75 |                 glShadeModel(GL_FLAT);
[  348s]       |                              ^~~~~~~
[  348s]       |                              GL_FLOAT
[  348s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:75:17: error: 'glShadeModel' was not declared in this scope
[  348s]    75 |                 glShadeModel(GL_FLAT);
[  348s]       |                 ^~~~~~~~~~~~
[  348s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:79:27: error: 'GL_TEXTURE_ENV' was not declared in this scope; did you mean 'GL_TEXTURE_3D'?
[  348s]    79 |                 glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
[  348s]       |                           ^~~~~~~~~~~~~~
[  348s]       |                           GL_TEXTURE_3D
[  349s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:79:43: error: 'GL_TEXTURE_ENV_MODE' was not declared in this scope; did you mean 'GL_TEXTURE_MAX_LOD'?
[  349s]    79 |                 glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
[  349s]       |                                           ^~~~~~~~~~~~~~~~~~~
[  349s]       |                                           GL_TEXTURE_MAX_LOD
[  349s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:79:17: error: 'glTexEnvf' was not declared in this scope
[  349s]    79 |                 glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
[  349s]       |                 ^~~~~~~~~
[  349s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:80:26: error: 'GL_LINE_SMOOTH' was not declared in this scope; did you mean 'GL_LINE_LOOP'?
[  349s]    80 |                 glEnable(GL_LINE_SMOOTH);
[  349s]       |                          ^~~~~~~~~~~~~~
[  349s]       |                          GL_LINE_LOOP
[  349s] /home/abuild/rpmbuild/BUILD/Wyrmgus-5.3.6/src/video/renderer.h:81:24: error: 'GL_LINE_SMOOTH_HINT' was not declared in this scope
[  349s]    81 |                 glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
[  349s]       |                        ^~~~~~~~~~~~~~~~~~~
```

for `aarch64`, that do not appear on AMD/Intel platforms. I didn't investigate any further, but it looks like the Qt GL infrastructure implicitly import `GL/gl.h` on `x64_64` and the like, while it does not on `aarch64`. 

See: https://build.opensuse.org/package/show/games/wyrmgus