### PR TITLE
Add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -37,3 +37,7 @@ Icon
 
 #Ignore Visual Studio project files
 build/
+
+# IDE and editor config
+.cursor/
+.vscode/

--- a/src/action/action_pickup.cpp
+++ b/src/action/action_pickup.cpp
@@ -38,6 +38,7 @@
 #include "database/preferences.h"
 #include "game/game.h"
 #include "iolib.h"
+#include "item/item_class.h"
 #include "item/persistent_item.h"
 #include "luacallback.h"
 #include "map/map_layer.h"

--- a/src/action/action_upgradeto.cpp
+++ b/src/action/action_upgradeto.cpp
@@ -32,6 +32,7 @@
 #include "animation/animation.h"
 #include "animation/animation_set.h"
 #include "database/defines.h"
+#include "economy/resource.h"
 #include "economy/resource_storage_type.h"
 //Wyrmgus start
 #include "game/game.h"

--- a/src/action/command.cpp
+++ b/src/action/command.cpp
@@ -58,6 +58,7 @@
 #include "unit/unit_manager.h"
 #include "unit/unit_type.h"
 #include "upgrade/upgrade.h"
+#include "upgrade/upgrade_structs.h"
 #include "util/assert_util.h"
 #include "util/vector_util.h"
 

--- a/src/ai/ai_plan.cpp
+++ b/src/ai/ai_plan.cpp
@@ -51,6 +51,7 @@
 #include "unit/unit_ref.h"
 #include "unit/unit_type.h"
 #include "upgrade/upgrade_modifier.h"
+#include "upgrade/upgrade_structs.h"
 #include "util/vector_util.h"
 
 class _EnemyOnMapTile final

--- a/src/ai/script_ai.cpp
+++ b/src/ai/script_ai.cpp
@@ -49,6 +49,7 @@
 #include "unit/unit_manager.h"
 #include "unit/unit_type.h"
 #include "upgrade/upgrade.h"
+#include "upgrade/upgrade_structs.h"
 #include "upgrade/upgrade_class.h"
 #include "util/assert_util.h"
 #include "util/log_util.h"

--- a/src/animation/animation_rotate.cpp
+++ b/src/animation/animation_rotate.cpp
@@ -32,6 +32,7 @@
 
 #include "actions.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "util/assert_util.h"
 
 /**

--- a/src/animation/animation_setvar.cpp
+++ b/src/animation/animation_setvar.cpp
@@ -36,6 +36,7 @@
 //Wyrmgus end
 #include "script.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "unit/unit_manager.h"
 #include "util/assert_util.h"
 #include "util/string_util.h"

--- a/src/animation/animation_spawnmissile.cpp
+++ b/src/animation/animation_spawnmissile.cpp
@@ -40,6 +40,7 @@
 #include "missile.h"
 #include "pathfinder/pathfinder.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "util/assert_util.h"
 
 void CAnimation_SpawnMissile::Action(CUnit &unit, int &/*move*/, int /*scale*/) const

--- a/src/game/difficulty.cpp
+++ b/src/game/difficulty.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<difficulty>;
-
 template <>
 const std::string enum_converter<difficulty>::property_class_identifier = "wyrmgus::difficulty";
 
@@ -45,5 +43,7 @@ const std::map<std::string, difficulty> enum_converter<difficulty>::string_to_en
 
 template <>
 const bool enum_converter<difficulty>::initialized = enum_converter::initialize();
+
+template class enum_converter<difficulty>;
 
 }

--- a/src/game/difficulty.h
+++ b/src/game/difficulty.h
@@ -62,6 +62,4 @@ inline std::string get_difficulty_name(const difficulty difficulty)
 
 }
 
-extern template class archimedes::enum_converter<difficulty>;
-
 Q_DECLARE_METATYPE(wyrmgus::difficulty)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -45,6 +45,7 @@
 #include "economy/resource.h"
 #include "editor.h"
 #include "engine_interface.h"
+#include "game/player_results_info.h"
 #include "game/results_info.h"
 //Wyrmgus start
 #include "grand_strategy.h"

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -56,6 +56,8 @@
 #include "unit/unit.h"
 #include "unit/unit_manager.h"
 #include "unit/unit_type.h"
+#include "upgrade/upgrade_structs.h"
+#include "economy/resource.h"
 #include "util/assert_util.h"
 #include "util/path_util.h"
 #include "util/random.h"

--- a/src/item/item_class.cpp
+++ b/src/item/item_class.cpp
@@ -32,8 +32,6 @@
 
 namespace archimedes {
 
-template class enum_converter<item_class>;
-
 template <>
 const std::string enum_converter<item_class>::property_class_identifier = "wyrmgus::item_class";
 
@@ -69,6 +67,8 @@ const std::map<std::string, item_class> enum_converter<item_class>::string_to_en
 
 template <>
 const bool enum_converter<item_class>::initialized = enum_converter::initialize();
+
+template class enum_converter<item_class>;
 
 }
 

--- a/src/item/item_class.h
+++ b/src/item/item_class.h
@@ -174,6 +174,4 @@ inline std::string get_item_class_name(const item_class item_class)
 
 }
 
-extern template class archimedes::enum_converter<item_class>;
-
 Q_DECLARE_METATYPE(wyrmgus::item_class)

--- a/src/item/item_slot.cpp
+++ b/src/item/item_slot.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<item_slot>;
-
 template <>
 const std::string enum_converter<item_slot>::property_class_identifier = "wyrmgus::item_slot";
 
@@ -51,5 +49,7 @@ const std::map<std::string, item_slot> enum_converter<item_slot>::string_to_enum
 
 template <>
 const bool enum_converter<item_slot>::initialized = enum_converter::initialize();
+
+template class enum_converter<item_slot>;
 
 }

--- a/src/item/item_slot.h
+++ b/src/item/item_slot.h
@@ -48,6 +48,4 @@ enum class item_slot {
 
 }
 
-extern template class archimedes::enum_converter<item_slot>;
-
 Q_DECLARE_METATYPE(wyrmgus::item_slot)

--- a/src/item/unique_item.cpp
+++ b/src/item/unique_item.cpp
@@ -35,6 +35,7 @@
 #include "ui/interface.h"
 #include "unit/unit.h"
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 #include "upgrade/upgrade.h"
 #include "upgrade/upgrade_modifier.h"
 #include "upgrade/upgrade_structs.h"

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -86,6 +86,7 @@
 #include "unit/unit_find.h"
 //Wyrmgus end
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 //Wyrmgus start
 #include "upgrade/upgrade.h"
 //Wyrmgus end

--- a/src/map/map_info.cpp
+++ b/src/map/map_info.cpp
@@ -29,6 +29,7 @@
 
 #include "map/map_info.h"
 
+#include "database/database.h"
 #include "map/map_layer.h"
 #include "map/map_presets.h"
 #include "map/map_settings.h"

--- a/src/map/map_layer.cpp
+++ b/src/map/map_layer.cpp
@@ -46,6 +46,7 @@
 #include "ui/ui.h"
 #include "unit/unit.h"
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 #include "util/assert_util.h"
 #include "util/point_util.h"
 

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -70,6 +70,7 @@
 #include "unit/historical_unit.h"
 #include "unit/unit.h"
 #include "unit/unit_class.h"
+#include "unit/unit_type.h"
 #include "util/exception_util.h"
 #include "util/log_util.h"
 #include "util/point_util.h"

--- a/src/map/tile.cpp
+++ b/src/map/tile.cpp
@@ -45,6 +45,7 @@
 #include "script.h"
 #include "unit/unit.h"
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 #include "util/util.h"
 #include "util/vector_util.h"
 

--- a/src/map/world_game_data.cpp
+++ b/src/map/world_game_data.cpp
@@ -42,6 +42,7 @@
 #include "ui/ui.h"
 #include "unit/unit.h"
 #include "unit/unit_find.h"
+#include "unit/unit_type.h"
 
 namespace wyrmgus {
 

--- a/src/missile/missile_class.cpp
+++ b/src/missile/missile_class.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<missile_class>;
-
 template <>
 const std::string enum_converter<missile_class>::property_class_identifier = "wyrmgus::missile_class";
 
@@ -59,5 +57,7 @@ const std::map<std::string, missile_class> enum_converter<missile_class>::string
 
 template <>
 const bool enum_converter<missile_class>::initialized = enum_converter::initialize();
+
+template class enum_converter<missile_class>;
 
 }

--- a/src/missile/missile_class.h
+++ b/src/missile/missile_class.h
@@ -56,6 +56,4 @@ enum class missile_class {
 
 }
 
-extern template class archimedes::enum_converter<missile_class>;
-
 Q_DECLARE_METATYPE(wyrmgus::missile_class)

--- a/src/player/civilization_group_rank.cpp
+++ b/src/player/civilization_group_rank.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<civilization_group_rank>;
-
 template <>
 const std::string enum_converter<civilization_group_rank>::property_class_identifier = "wyrmgus::civilization_group_rank";
 
@@ -44,5 +42,7 @@ const std::map<std::string, civilization_group_rank> enum_converter<civilization
 
 template <>
 const bool enum_converter<civilization_group_rank>::initialized = enum_converter::initialize();
+
+template class enum_converter<civilization_group_rank>;
 
 }

--- a/src/player/civilization_group_rank.h
+++ b/src/player/civilization_group_rank.h
@@ -39,6 +39,4 @@ enum class civilization_group_rank {
 
 }
 
-extern template class archimedes::enum_converter<civilization_group_rank>;
-
 Q_DECLARE_METATYPE(wyrmgus::civilization_group_rank)

--- a/src/player/faction_tier.cpp
+++ b/src/player/faction_tier.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<faction_tier>;
-
 template <>
 const std::string enum_converter<faction_tier>::property_class_identifier = "wyrmgus::faction_tier";
 
@@ -50,5 +48,7 @@ const std::map<std::string, faction_tier> enum_converter<faction_tier>::string_t
 
 template <>
 const bool enum_converter<faction_tier>::initialized = enum_converter::initialize();
+
+template class enum_converter<faction_tier>;
 
 }

--- a/src/player/faction_tier.h
+++ b/src/player/faction_tier.h
@@ -74,6 +74,4 @@ inline std::string get_faction_tier_name(const faction_tier tier)
 
 }
 
-extern template class archimedes::enum_converter<faction_tier>;
-
 Q_DECLARE_METATYPE(wyrmgus::faction_tier)

--- a/src/player/faction_type.cpp
+++ b/src/player/faction_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<faction_type>;
-
 template <>
 const std::string enum_converter<faction_type>::property_class_identifier = "wyrmgus::faction_type";
 
@@ -49,5 +47,7 @@ const std::map<std::string, faction_type> enum_converter<faction_type>::string_t
 
 template <>
 const bool enum_converter<faction_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<faction_type>;
 
 }

--- a/src/player/faction_type.h
+++ b/src/player/faction_type.h
@@ -86,6 +86,4 @@ inline std::string get_faction_type_name(const faction_type type)
 
 }
 
-extern template class archimedes::enum_converter<faction_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::faction_type)

--- a/src/player/government_type.cpp
+++ b/src/player/government_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<government_type>;
-
 template <>
 const std::string enum_converter<government_type>::property_class_identifier = "wyrmgus::government_type";
 
@@ -46,5 +44,7 @@ const std::map<std::string, government_type> enum_converter<government_type>::st
 
 template <>
 const bool enum_converter<government_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<government_type>;
 
 }

--- a/src/player/government_type.h
+++ b/src/player/government_type.h
@@ -71,6 +71,4 @@ inline bool can_government_type_have_dynasty(const government_type government_ty
 
 }
 
-extern template class archimedes::enum_converter<government_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::government_type)

--- a/src/quest/objective_type.cpp
+++ b/src/quest/objective_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<objective_type>;
-
 template <>
 const std::string enum_converter<objective_type>::property_class_identifier = "wyrmgus::objective_type";
 
@@ -54,5 +52,7 @@ const std::map<std::string, objective_type> enum_converter<objective_type>::stri
 
 template <>
 const bool enum_converter<objective_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<objective_type>;
 
 }

--- a/src/quest/objective_type.h
+++ b/src/quest/objective_type.h
@@ -48,6 +48,4 @@ enum class objective_type {
 
 }
 
-extern template class archimedes::enum_converter<objective_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::objective_type)

--- a/src/script/condition/condition.cpp
+++ b/src/script/condition/condition.cpp
@@ -102,6 +102,7 @@
 #include "translator.h"
 #include "ui/button.h"
 #include "ui/interface.h"
+#include "unit/unit_type.h"
 #include "upgrade/upgrade_modifier.h"
 #include "util/string_util.h"
 #include "util/vector_util.h"

--- a/src/script/condition/condition.h
+++ b/src/script/condition/condition.h
@@ -28,11 +28,11 @@
 
 #include "script/context.h"
 #include "unit/unit.h"
+#include "upgrade/upgrade_structs.h"
 
 class CConfigData;
 class CPlayer;
 class CUnit;
-class CUpgrade;
 
 namespace archimedes {
 	class gsml_data;

--- a/src/script/condition/not_condition.cpp
+++ b/src/script/condition/not_condition.cpp
@@ -43,10 +43,10 @@ not_condition<scope_type>::not_condition(std::vector<std::unique_ptr<const condi
 }
 
 template <typename scope_type>
-not_condition<scope_type>::not_condition(std::unique_ptr<const condition<scope_type>> &&condition)
+not_condition<scope_type>::not_condition(std::unique_ptr<const condition<scope_type>> &&condition_ptr)
 	: condition<scope_type>(gsml_operator::assignment)
 {
-	this->conditions.push_back(std::move(condition));
+	this->conditions.push_back(std::move(condition_ptr));
 }
 
 template class not_condition<CPlayer>;

--- a/src/script/trigger_target.cpp
+++ b/src/script/trigger_target.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<trigger_target>;
-
 template <>
 const std::string enum_converter<trigger_target>::property_class_identifier = "wyrmgus::trigger_target";
 
@@ -44,5 +42,7 @@ const std::map<std::string, trigger_target> enum_converter<trigger_target>::stri
 
 template <>
 const bool enum_converter<trigger_target>::initialized = enum_converter::initialize();
+
+template class enum_converter<trigger_target>;
 
 }

--- a/src/script/trigger_target.h
+++ b/src/script/trigger_target.h
@@ -38,6 +38,4 @@ enum class trigger_target {
 
 }
 
-extern template class archimedes::enum_converter<trigger_target>;
-
 Q_DECLARE_METATYPE(wyrmgus::trigger_target)

--- a/src/script/trigger_type.cpp
+++ b/src/script/trigger_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<trigger_type>;
-
 template <>
 const std::string enum_converter<trigger_type>::property_class_identifier = "wyrmgus::trigger_type";
 
@@ -44,5 +42,7 @@ const std::map<std::string, trigger_type> enum_converter<trigger_type>::string_t
 
 template <>
 const bool enum_converter<trigger_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<trigger_type>;
 
 }

--- a/src/script/trigger_type.h
+++ b/src/script/trigger_type.h
@@ -38,6 +38,4 @@ enum class trigger_type {
 
 }
 
-extern template class archimedes::enum_converter<trigger_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::trigger_type)

--- a/src/sound/music_type.cpp
+++ b/src/sound/music_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<music_type>;
-
 template <>
 const std::string enum_converter<music_type>::property_class_identifier = "wyrmgus::music_type";
 
@@ -48,5 +46,7 @@ const std::map<std::string, music_type> enum_converter<music_type>::string_to_en
 
 template <>
 const bool enum_converter<music_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<music_type>;
 
 }

--- a/src/sound/music_type.h
+++ b/src/sound/music_type.h
@@ -42,6 +42,4 @@ enum class music_type {
 
 }
 
-extern template class archimedes::enum_converter<music_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::music_type)

--- a/src/species/ecological_niche.cpp
+++ b/src/species/ecological_niche.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<ecological_niche>;
-
 template <>
 const std::string enum_converter<ecological_niche>::property_class_identifier = "wyrmgus::ecological_niche";
 
@@ -45,5 +43,7 @@ const std::map<std::string, ecological_niche> enum_converter<ecological_niche>::
 
 template <>
 const bool enum_converter<ecological_niche>::initialized = enum_converter::initialize();
+
+template class enum_converter<ecological_niche>;
 
 }

--- a/src/species/ecological_niche.h
+++ b/src/species/ecological_niche.h
@@ -41,6 +41,4 @@ enum class ecological_niche {
 
 }
 
-extern template class archimedes::enum_converter<ecological_niche>;
-
 Q_DECLARE_METATYPE(wyrmgus::ecological_niche)

--- a/src/species/geological_era.cpp
+++ b/src/species/geological_era.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<geological_era>;
-
 template <>
 const std::string enum_converter<geological_era>::property_class_identifier = "wyrmgus::geological_era";
 
@@ -55,5 +53,7 @@ const std::map<std::string, geological_era> enum_converter<geological_era>::stri
 
 template <>
 const bool enum_converter<geological_era>::initialized = enum_converter::initialize();
+
+template class enum_converter<geological_era>;
 
 }

--- a/src/species/geological_era.h
+++ b/src/species/geological_era.h
@@ -49,6 +49,4 @@ enum class geological_era {
 
 }
 
-extern template class archimedes::enum_converter<geological_era>;
-
 Q_DECLARE_METATYPE(wyrmgus::geological_era)

--- a/src/species/species.cpp
+++ b/src/species/species.cpp
@@ -34,6 +34,7 @@
 #include "species/geological_era.h"
 #include "species/taxon.h"
 #include "species/taxonomic_rank.h"
+#include "unit/unit_type.h"
 #include "util/vector_random_util.h"
 #include "util/vector_util.h"
 

--- a/src/species/taxonomic_rank.cpp
+++ b/src/species/taxonomic_rank.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<taxonomic_rank>;
-
 template <>
 const std::string enum_converter<taxonomic_rank>::property_class_identifier = "wyrmgus::taxonomic_rank";
 
@@ -64,5 +62,7 @@ const std::map<std::string, taxonomic_rank> enum_converter<taxonomic_rank>::stri
 
 template <>
 const bool enum_converter<taxonomic_rank>::initialized = enum_converter::initialize();
+
+template class enum_converter<taxonomic_rank>;
 
 }

--- a/src/species/taxonomic_rank.h
+++ b/src/species/taxonomic_rank.h
@@ -59,6 +59,4 @@ enum class taxonomic_rank {
 
 }
 
-extern template class archimedes::enum_converter<taxonomic_rank>;
-
 Q_DECLARE_METATYPE(wyrmgus::taxonomic_rank)

--- a/src/spell/spell.cpp
+++ b/src/spell/spell.cpp
@@ -60,6 +60,7 @@
 #include "spell/status_effect.h"
 #include "unit/unit.h"
 #include "unit/unit_find.h"
+#include "unit/unit_type.h"
 #include "upgrade/upgrade.h"
 #include "util/assert_util.h"
 #include "util/string_conversion_util.h"

--- a/src/spell/spell_action_adjust_variable.cpp
+++ b/src/spell/spell_action_adjust_variable.cpp
@@ -35,6 +35,7 @@
 #include "include/config.h"
 #include "script.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "util/string_conversion_util.h"
 #include "util/string_util.h"
 

--- a/src/spell/spell_action_summon.cpp
+++ b/src/spell/spell_action_summon.cpp
@@ -39,6 +39,7 @@
 #include "spell/spell.h"
 #include "unit/unit.h"
 #include "unit/unit_find.h"
+#include "unit/unit_type.h"
 #include "util/string_conversion_util.h"
 
 namespace wyrmgus {

--- a/src/spell/spell_polymorph.cpp
+++ b/src/spell/spell_polymorph.cpp
@@ -47,6 +47,7 @@
 //Wyrmgus start
 #include "unit/unit_find.h"
 //Wyrmgus end
+#include "unit/unit_type.h"
 #include "util/vector_util.h"
 
 void Spell_Polymorph::Parse(lua_State *l, int startIndex, int endIndex)

--- a/src/spell/spell_spawnportal.cpp
+++ b/src/spell/spell_spawnportal.cpp
@@ -34,6 +34,7 @@
 #include "player/player.h"
 #include "script.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 
 void Spell_SpawnPortal::Parse(lua_State *l, int startIndex, int endIndex)
 {

--- a/src/spell/spell_target_type.cpp
+++ b/src/spell/spell_target_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<spell_target_type>;
-
 template <>
 const std::string enum_converter<spell_target_type>::property_class_identifier = "wyrmgus::spell_target_type";
 
@@ -44,5 +42,7 @@ const std::map<std::string, spell_target_type> enum_converter<spell_target_type>
 
 template <>
 const bool enum_converter<spell_target_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<spell_target_type>;
 
 }

--- a/src/spell/spell_target_type.h
+++ b/src/spell/spell_target_type.h
@@ -38,6 +38,4 @@ enum class spell_target_type {
 
 }
 
-extern template class archimedes::enum_converter<spell_target_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::spell_target_type)

--- a/src/stratagus/character.cpp
+++ b/src/stratagus/character.cpp
@@ -60,6 +60,7 @@
 #include "ui/icon.h"
 #include "unit/unit.h"
 #include "unit/unit_class.h"
+#include "unit/unit_type.h"
 #include "unit/unit_type_variation.h"
 #include "unit/variation_tag.h"
 #include "upgrade/upgrade.h"

--- a/src/stratagus/character_title.cpp
+++ b/src/stratagus/character_title.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<character_title>;
-
 template <>
 const std::string enum_converter<character_title>::property_class_identifier = "wyrmgus::character_title";
 
@@ -45,5 +43,7 @@ const std::map<std::string, character_title> enum_converter<character_title>::st
 
 template <>
 const bool enum_converter<character_title>::initialized = enum_converter::initialize();
+
+template class enum_converter<character_title>;
 
 }

--- a/src/stratagus/character_title.h
+++ b/src/stratagus/character_title.h
@@ -41,6 +41,4 @@ enum class character_title {
 
 }
 
-extern template class archimedes::enum_converter<character_title>;
-
 Q_DECLARE_METATYPE(wyrmgus::character_title)

--- a/src/stratagus/main.cpp
+++ b/src/stratagus/main.cpp
@@ -82,6 +82,8 @@
 #include <QQuickWindow>
 #pragma warning(pop)
 
+#include <cstdlib>
+
 static QCoro::Task<void> start_stratagus(const int argc, char **argv)
 {
 	try {
@@ -204,7 +206,7 @@ int main(int argc, char **argv)
 
 		stratagus_on_exit_cleanup();
 
-		return result;
+		std::_Exit(result);
 	} catch (...) {
 		exception::report(std::current_exception());
 		return -1;

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -197,6 +197,7 @@ extern void beos_init(int argc, char **argv);
 #include "ui/interface.h"
 #include "ui/ui.h"
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 #include "util/exception_util.h"
 #include "util/log_util.h"
 #include "util/path_util.h"

--- a/src/ui/button.cpp
+++ b/src/ui/button.cpp
@@ -47,6 +47,7 @@
 #include "unit/unit.h"
 #include "unit/unit_class.h"
 #include "unit/unit_manager.h"
+#include "unit/unit_type.h"
 #include "upgrade/upgrade.h"
 #include "upgrade/upgrade_class.h"
 #include "util/string_conversion_util.h"

--- a/src/ui/contenttype.cpp
+++ b/src/ui/contenttype.cpp
@@ -39,6 +39,7 @@
 #include "ui/icon.h"
 #include "ui/ui.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "util/assert_util.h"
 #include "video/font.h"
 #include "video/video.h"

--- a/src/ui/cursor_type.cpp
+++ b/src/ui/cursor_type.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<cursor_type>;
-
 template <>
 const std::string enum_converter<cursor_type>::property_class_identifier = "wyrmgus::cursor_type";
 
@@ -56,5 +54,7 @@ const std::map<std::string, cursor_type> enum_converter<cursor_type>::string_to_
 
 template <>
 const bool enum_converter<cursor_type>::initialized = enum_converter::initialize();
+
+template class enum_converter<cursor_type>;
 
 }

--- a/src/ui/cursor_type.h
+++ b/src/ui/cursor_type.h
@@ -52,6 +52,4 @@ enum class cursor_type {
 
 }
 
-extern template class archimedes::enum_converter<cursor_type>;
-
 Q_DECLARE_METATYPE(wyrmgus::cursor_type)

--- a/src/ui/hotkey_setup.cpp
+++ b/src/ui/hotkey_setup.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<hotkey_setup>;
-
 template <>
 const std::string enum_converter<hotkey_setup>::property_class_identifier = "wyrmgus::hotkey_setup";
 
@@ -44,5 +42,7 @@ const std::map<std::string, hotkey_setup> enum_converter<hotkey_setup>::string_t
 
 template <>
 const bool enum_converter<hotkey_setup>::initialized = enum_converter::initialize();
+
+template class enum_converter<hotkey_setup>;
 
 }

--- a/src/ui/hotkey_setup.h
+++ b/src/ui/hotkey_setup.h
@@ -56,6 +56,4 @@ inline std::string get_hotkey_setup_name(const hotkey_setup hotkey_setup)
 
 }
 
-extern template class archimedes::enum_converter<hotkey_setup>;
-
 Q_DECLARE_METATYPE(wyrmgus::hotkey_setup)

--- a/src/unit/unit_domain.cpp
+++ b/src/unit/unit_domain.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<unit_domain>;
-
 template <>
 const std::string enum_converter<unit_domain>::property_class_identifier = "wyrmgus::unit_domain";
 
@@ -46,5 +44,7 @@ const std::map<std::string, unit_domain> enum_converter<unit_domain>::string_to_
 
 template <>
 const bool enum_converter<unit_domain>::initialized = enum_converter::initialize();
+
+template class enum_converter<unit_domain>;
 
 }

--- a/src/unit/unit_domain.h
+++ b/src/unit/unit_domain.h
@@ -41,6 +41,4 @@ enum class unit_domain {
 
 }
 
-extern template class archimedes::enum_converter<unit_domain>;
-
 Q_DECLARE_METATYPE(wyrmgus::unit_domain)

--- a/src/unit/unit_manager.cpp
+++ b/src/unit/unit_manager.cpp
@@ -33,6 +33,7 @@
 #include "script.h"
 #include "unit/unit_manager.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "util/assert_util.h"
 #include "util/exception_util.h"
 #include "util/list_util.h"

--- a/src/upgrade/upgrade.h
+++ b/src/upgrade/upgrade.h
@@ -29,9 +29,10 @@
 
 #pragma once
 
+#include "upgrade/upgrade_structs.h"
+
 class CFile;
 class CPlayer;
-class CUpgrade;
 class CUnit;
 
 namespace wyrmgus {

--- a/src/upgrade/upgrade.h
+++ b/src/upgrade/upgrade.h
@@ -29,10 +29,9 @@
 
 #pragma once
 
-#include "upgrade/upgrade_structs.h"
-
 class CFile;
 class CPlayer;
+class CUpgrade;
 class CUnit;
 
 namespace wyrmgus {

--- a/src/upgrade/upgrade_category_rank.cpp
+++ b/src/upgrade/upgrade_category_rank.cpp
@@ -30,8 +30,6 @@
 
 namespace archimedes {
 
-template class enum_converter<upgrade_category_rank>;
-
 template <>
 const std::string enum_converter<upgrade_category_rank>::property_class_identifier = "wyrmgus::upgrade_category_rank";
 
@@ -44,5 +42,7 @@ const std::map<std::string, upgrade_category_rank> enum_converter<upgrade_catego
 
 template <>
 const bool enum_converter<upgrade_category_rank>::initialized = enum_converter::initialize();
+
+template class enum_converter<upgrade_category_rank>;
 
 }

--- a/src/upgrade/upgrade_category_rank.h
+++ b/src/upgrade/upgrade_category_rank.h
@@ -41,6 +41,4 @@ enum class upgrade_category_rank {
 
 }
 
-extern template class archimedes::enum_converter<upgrade_category_rank>;
-
 Q_DECLARE_METATYPE(wyrmgus::upgrade_category_rank)

--- a/src/video/renderer.cpp
+++ b/src/video/renderer.cpp
@@ -77,14 +77,18 @@ QSizeF renderer::get_target_sizef() const
 
 void renderer::init_opengl()
 {
-	this->paint_device = std::make_unique<QOpenGLPaintDevice>(this->get_target_size());
-	this->paint_device->setPaintFlipped(true);
-	this->painter = std::make_unique<QPainter>(this->paint_device.get());
-
+	const QSize fbo_physical_size = this->framebufferObject()->size();
 	const QSizeF target_sizef = this->get_target_sizef();
 	const QSize target_size = target_sizef.toSize();
 
-	glViewport(0, 0, static_cast<GLsizei>(target_size.width()), static_cast<GLsizei>(target_size.height()));
+	this->paint_device = std::make_unique<QOpenGLPaintDevice>(fbo_physical_size);
+	this->paint_device->setPaintFlipped(true);
+	if (target_size.width() > 0) {
+		this->paint_device->setDevicePixelRatio(static_cast<qreal>(fbo_physical_size.width()) / target_size.width());
+	}
+	this->painter = std::make_unique<QPainter>(this->paint_device.get());
+
+	glViewport(0, 0, static_cast<GLsizei>(fbo_physical_size.width()), static_cast<GLsizei>(fbo_physical_size.height()));
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();

--- a/src/video/renderer.h
+++ b/src/video/renderer.h
@@ -27,7 +27,11 @@
 #pragma once
 
 #pragma warning(push, 0)
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <QOpenGLTexture>
 #include <QOpenGLTextureBlitter>
 #pragma warning(pop)


### PR DESCRIPTION
## Summary

- Fix OpenGL header include path for Apple platforms (`OpenGL/gl.h` vs `GL/gl.h`)
- Fix OpenGL renderer to use physical framebuffer size and device pixel ratio for correct rendering on Retina/HiDPI displays
- Use `std::_Exit()` for clean shutdown to avoid Qt cleanup crashes on macOS
- Move explicit `enum_converter` template instantiations to end of `.cpp` files and remove `extern template` declarations from headers, to fix Apple Clang compilation errors (same pattern as the Archimedes PR)
- Rename shadowed parameter in `not_condition` constructor
- Add missing includes (`cstdlib`, `upgrade_structs.h`) and replace forward declarations where full type is needed
- Update `.gitignore` for macOS artifacts
- Update archimedes submodule to include macOS compatibility fixes

## Context

This is part of a set of three PRs (across Archimedes, Wyrmgus, and Wyrmsun) to add macOS support:
- Archimedes PR: https://github.com/Andrettin/Archimedes/pull/2
- Wyrmsun PR: (will link after creation)

Related issue: https://github.com/Andrettin/Wyrmsun/issues/219

**Note:** This PR depends on the Archimedes PR being merged first, as it updates the submodule pointer.

## Test plan

- [x] Builds successfully on macOS 26.3 (arm64, Apple Silicon) with Homebrew Qt6
- [x] All existing tests pass
- [x] Game runs and plays correctly on macOS (including Retina display rendering)